### PR TITLE
Install fastly-cli

### DIFF
--- a/roles/development/vars/main.yml
+++ b/roles/development/vars/main.yml
@@ -14,6 +14,7 @@ cask_packages:
   - visual-studio-code
 
 npm_packages:
+  - fastly-cli
   - firebase-tools
 
 vscode_extensions:


### PR DESCRIPTION
fastly-cli is an NPM package to configure and administer @portovep's favourite CDN from his terminal.